### PR TITLE
Increase test coverage in envutil package

### DIFF
--- a/envutil/envutil_test.go
+++ b/envutil/envutil_test.go
@@ -23,6 +23,7 @@ func TestParseEnvValue(t *testing.T) {
 		{"EnvKey6", "", "${ EnvKey6 | app=run }", "app=run"},
 		{"EnvKey7", "", "${ EnvKey7 | app.run }", "app.run"},
 		{"EnvKey8", "", "${ EnvKey7 | app/run }", "app/run"},
+		{"EnvKey9", "", "test_value", "test_value"},
 		{"TEST_SHELL", "/bin/zsh", "${TEST_SHELL|/bin/bash}", "/bin/zsh"},
 		{"TEST_SHELL", "", "${TEST_SHELL|/bin/bash}", "/bin/bash"},
 	}

--- a/envutil/get_test.go
+++ b/envutil/get_test.go
@@ -1,0 +1,26 @@
+package envutil
+
+import (
+	"testing"
+
+	"github.com/gookit/goutil/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	TestEnvName         = "TEST_GOUTIL_ENV"
+	TestNoEnvName       = "TEST_GOUTIL_NO_ENV"
+	TestEnvValue        = "1"
+	DefaultTestEnvValue = "1"
+)
+
+func TestGetenv(t *testing.T) {
+	testutil.MockEnvValues(map[string]string{
+		TestEnvName: TestEnvValue,
+	}, func() {
+		envValue := Getenv(TestEnvName)
+		assert.Equal(t, TestEnvValue, envValue, "env value not equals")
+		envValue = Getenv(TestNoEnvName, DefaultTestEnvValue)
+		assert.Equal(t, DefaultTestEnvValue, envValue, "env value not default")
+	})
+}

--- a/envutil/info_test.go
+++ b/envutil/info_test.go
@@ -71,6 +71,11 @@ func TestIsSupportColor(t *testing.T) {
 		is.True(envutil.IsSupportColor())
 	})
 
+	// TERM
+	testutil.MockEnvValue("TERM", "", func(_ string) {
+		is.False(envutil.IsSupportColor())
+	})
+
 	is.NoError(os.Setenv("TERM", "xterm-vt220"))
 	is.True(envutil.IsSupportColor())
 	// revert


### PR DESCRIPTION
close: #9 As far as I test in go command. The test coverage rate in envutil has been increased to 100%