### PR TITLE
Optimize strutil/format and arrutil/slice

### DIFF
--- a/arrutil/slice.go
+++ b/arrutil/slice.go
@@ -99,16 +99,17 @@ func Contains(arr, val interface{}) bool {
 	if strVal, ok := val.(string); ok {
 		if ss, ok := arr.([]string); ok {
 			return StringsHas(ss, strVal)
-		} else {
-			rv := reflect.ValueOf(arr)
-			if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
-				for i := 0; i < rv.Len(); i++ {
-					if v, ok := rv.Index(i).Interface().(string); ok && strings.EqualFold(v, strVal) {
-						return true
-					}
+		}
+
+		rv := reflect.ValueOf(arr)
+		if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+			for i := 0; i < rv.Len(); i++ {
+				if v, ok := rv.Index(i).Interface().(string); ok && strings.EqualFold(v, strVal) {
+					return true
 				}
 			}
 		}
+		
 		return false
 	}
 
@@ -129,6 +130,19 @@ func NotContains(arr, val interface{}) bool {
 	return false == Contains(arr, val)
 }
 
+// GetRandomOne get random element from an array/slice
+func GetRandomOne(arr interface{}) interface{} {
+	rv := reflect.ValueOf(arr)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return arr
+	}
+
+	i := mathutil.RandomInt(0, rv.Len())
+	r := rv.Index(i).Interface()
+
+	return r
+}
+
 func toInt64Slice(arr interface{}) (ret []int64, ok bool) {
 	rv := reflect.ValueOf(arr)
 	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
@@ -146,17 +160,4 @@ func toInt64Slice(arr interface{}) (ret []int64, ok bool) {
 
 	ok = true
 	return
-}
-
-func GetRandomOne(arr interface{}) interface{} {
-	rv := reflect.ValueOf(arr)
-	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
-		return arr
-	}
-
-	i := mathutil.RandomInt(0, rv.Len())
-
-	r := rv.Index(i).Interface()
-
-	return r
 }

--- a/arrutil/slice.go
+++ b/arrutil/slice.go
@@ -99,6 +99,15 @@ func Contains(arr, val interface{}) bool {
 	if strVal, ok := val.(string); ok {
 		if ss, ok := arr.([]string); ok {
 			return StringsHas(ss, strVal)
+		} else {
+			rv := reflect.ValueOf(arr)
+			if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+				for i := 0; i < rv.Len(); i++ {
+					if v, ok := rv.Index(i).Interface().(string); ok && strings.EqualFold(v, strVal) {
+						return true
+					}
+				}
+			}
 		}
 		return false
 	}
@@ -122,7 +131,7 @@ func NotContains(arr, val interface{}) bool {
 
 func toInt64Slice(arr interface{}) (ret []int64, ok bool) {
 	rv := reflect.ValueOf(arr)
-	if rv.Kind() != reflect.Slice {
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
 		return
 	}
 
@@ -137,4 +146,17 @@ func toInt64Slice(arr interface{}) (ret []int64, ok bool) {
 
 	ok = true
 	return
+}
+
+func GetRandomOne(arr interface{}) interface{} {
+	rv := reflect.ValueOf(arr)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return arr
+	}
+
+	i := mathutil.RandomInt(0, rv.Len())
+
+	r := rv.Index(i).Interface()
+
+	return r
 }

--- a/arrutil/slice_test.go
+++ b/arrutil/slice_test.go
@@ -69,21 +69,25 @@ func TestStringsHas(t *testing.T) {
 func TestContains(t *testing.T) {
 	is := assert.New(t)
 	tests := map[interface{}]interface{}{
-		1:   []int{1, 2, 3},
-		2:   []int8{1, 2, 3},
-		3:   []int16{1, 2, 3},
-		4:   []int32{4, 2, 3},
-		5:   []int64{5, 2, 3},
-		6:   []uint{6, 2, 3},
-		7:   []uint8{7, 2, 3},
-		8:   []uint16{8, 2, 3},
-		9:   []uint32{9, 2, 3},
-		10:  []uint64{10, 3},
-		11:  []string{"11", "3"},
-		'a': []int64{97},
-		'b': []rune{'a', 'b'},
-		'c': []byte{'a', 'b', 'c'}, // byte -> uint8
-		"a": []string{"a", "b", "c"},
+		1:    []int{1, 2, 3},
+		2:    []int8{1, 2, 3},
+		3:    []int16{1, 2, 3},
+		4:    []int32{4, 2, 3},
+		5:    []int64{5, 2, 3},
+		6:    []uint{6, 2, 3},
+		7:    []uint8{7, 2, 3},
+		8:    []uint16{8, 2, 3},
+		9:    []uint32{9, 2, 3},
+		10:   []uint64{10, 3},
+		11:   []string{"11", "3"},
+		'a':  []int64{97},
+		'b':  []rune{'a', 'b'},
+		'c':  []byte{'a', 'b', 'c'}, // byte -> uint8
+		"a":  []string{"a", "b", "c"},
+		12:   [5]uint{12, 1, 2, 3, 4},
+		'A':  [3]rune{'A', 'B', 'C'},
+		'd':  [4]byte{'a', 'b', 'c', 'd'},
+		"aa": [3]string{"aa", "bb", "cc"},
 	}
 
 	for val, list := range tests {
@@ -108,4 +112,83 @@ func TestContains(t *testing.T) {
 		is.True(arrutil.NotContains(list, val))
 		is.False(arrutil.Contains(list, val))
 	}
+}
+
+func TestGetRandomOne(t *testing.T) {
+	is := assert.New(t)
+	// int slice
+	intSlice := []int{1, 2, 3, 4, 5, 6}
+	intVal := arrutil.GetRandomOne(intSlice)
+	intVal1 := arrutil.GetRandomOne(intSlice)
+	for intVal == intVal1 {
+		intVal1 = arrutil.GetRandomOne(intSlice)
+	}
+	assert.IsType(t, 0, intVal)
+	is.True(arrutil.Contains(intSlice, intVal))
+	assert.IsType(t, 0, intVal1)
+	is.True(arrutil.Contains(intSlice, intVal1))
+	assert.NotEqual(t, intVal, intVal1)
+
+	// int array
+	intArray := [6]int{1, 2, 3, 4, 5, 6}
+	intReturned := arrutil.GetRandomOne(intArray)
+	intReturned1 := arrutil.GetRandomOne(intArray)
+	for intReturned == intReturned1 {
+		intReturned1 = arrutil.GetRandomOne(intArray)
+	}
+	assert.IsType(t, 0, intReturned)
+	is.True(arrutil.Contains(intArray, intReturned))
+	assert.IsType(t, 0, intReturned1)
+	is.True(arrutil.Contains(intArray, intReturned1))
+	assert.NotEqual(t, intReturned, intReturned1)
+
+	// string slice
+	strSlice := []string{"aa", "bb", "cc", "dd"}
+	strVal := arrutil.GetRandomOne(strSlice)
+	strVal1 := arrutil.GetRandomOne(strSlice)
+	for strVal == strVal1 {
+		strVal1 = arrutil.GetRandomOne(strSlice)
+	}
+	assert.IsType(t, string(""), strVal)
+	is.True(arrutil.Contains(strSlice, strVal))
+	assert.IsType(t, string(""), strVal1)
+	is.True(arrutil.Contains(strSlice, strVal1))
+	assert.NotEqual(t, strVal, strVal1)
+
+	// string array
+	strArray := [4]string{"aa", "bb", "cc", "dd"}
+	strReturned := arrutil.GetRandomOne(strArray)
+	strReturned1 := arrutil.GetRandomOne(strArray)
+	for strReturned == strReturned1 {
+		strReturned1 = arrutil.GetRandomOne(strArray)
+	}
+	assert.IsType(t, "", strReturned)
+	is.True(arrutil.Contains(strArray, strReturned))
+	assert.IsType(t, "", strReturned1)
+	is.True(arrutil.Contains(strArray, strReturned1))
+	assert.NotEqual(t, strReturned, strReturned1)
+
+	// byte slice
+	byteSlice := []byte("abcdefg")
+	byteVal := arrutil.GetRandomOne(byteSlice)
+	byteVal1 := arrutil.GetRandomOne(byteSlice)
+	for byteVal == byteVal1 {
+		byteVal1 = arrutil.GetRandomOne(byteSlice)
+	}
+	assert.IsType(t, byte('a'), byteVal)
+	is.True(arrutil.Contains(byteSlice, byteVal))
+	assert.IsType(t, byte('a'), byteVal1)
+	is.True(arrutil.Contains(byteSlice, byteVal1))
+	assert.NotEqual(t, byteVal, byteVal1)
+
+	// int
+	invalidIntData := int(404)
+	invalidIntReturned := arrutil.GetRandomOne(invalidIntData)
+	assert.IsType(t, int(0), invalidIntReturned)
+
+	// float
+	invalidDataFloat := float32(3.14)
+	invalidFloatReturned := arrutil.GetRandomOne(invalidDataFloat)
+	assert.IsType(t, float32(3.1), invalidFloatReturned)
+
 }

--- a/strutil/format.go
+++ b/strutil/format.go
@@ -32,12 +32,58 @@ func UpperWord(s string) string {
 		return s
 	}
 
-	ss := strings.Split(s, " ")
-	ns := make([]string, len(ss))
-	for i, word := range ss {
-		ns[i] = UpperFirst(word)
+	if len(s) == 1 {
+		return strings.ToUpper(s)
 	}
-	return strings.Join(ns, " ")
+
+	var inWord bool
+	var buf []byte
+
+	for i:=0;; {
+		if isLowerChar(s[i]) {
+			buf = append(buf, []byte(strings.ToUpper(string(s[i])))...)
+		} else {
+			buf = append(buf, []byte(string(s[i]))...)
+		}
+		inWord = true
+		for j:=i+1; j<len(s); j++{
+			if !isWord(s[i]) && isWord(s[j]) {
+				inWord = false
+			}
+
+			if isLowerChar(s[j]) && !inWord {
+				buf = append(buf, []byte(strings.ToUpper(string(s[j])))...)
+				inWord = true
+			} else {
+				buf = append(buf, []byte(string(s[j]))...)
+				if isWord(s[j]) {
+					inWord = true
+				}
+			}
+			i++
+		}
+		break
+	}
+
+	//ss := strings.Split(s, " ")
+	//ns := make([]string, len(ss))
+	//for i, word := range ss {
+	//	ns[i] = UpperFirst(word)
+	//}
+
+	return string(buf)
+}
+
+func isWord(c uint8) bool {
+	return isLowerChar(c) || isUpperChar(c)
+}
+
+func isLowerChar(c uint8) bool {
+	return 'a' <= c && c <= 'z'
+}
+
+func isUpperChar(c uint8) bool {
+	return 'A' <= c && c <= 'Z'
 }
 
 // LowerFirst lower first char

--- a/strutil/format.go
+++ b/strutil/format.go
@@ -3,6 +3,7 @@ package strutil
 import (
 	"regexp"
 	"strings"
+	"unicode"
 )
 
 // Some alias methods.
@@ -36,54 +37,37 @@ func UpperWord(s string) string {
 		return strings.ToUpper(s)
 	}
 
-	var inWord bool
-	var buf []byte
+	inWord := true
+	buf := make([]byte, 0, len(s))
 
-	for i:=0;; {
-		if isLowerChar(s[i]) {
-			buf = append(buf, []byte(strings.ToUpper(string(s[i])))...)
-		} else {
-			buf = append(buf, []byte(string(s[i]))...)
-		}
-		inWord = true
-		for j:=i+1; j<len(s); j++{
-			if !isWord(s[i]) && isWord(s[j]) {
-				inWord = false
-			}
-
-			if isLowerChar(s[j]) && !inWord {
-				buf = append(buf, []byte(strings.ToUpper(string(s[j])))...)
-				inWord = true
-			} else {
-				buf = append(buf, []byte(string(s[j]))...)
-				if isWord(s[j]) {
-					inWord = true
-				}
-			}
-			i++
-		}
-		break
+	i := 0
+	rs := []rune(s)
+	if runeIsLowerChar(rs[i]) {
+		buf = append(buf, []byte(string(unicode.ToUpper(rs[i])))...)
+	} else {
+		buf = append(buf, []byte(string(rs[i]))...)
 	}
 
-	//ss := strings.Split(s, " ")
-	//ns := make([]string, len(ss))
-	//for i, word := range ss {
-	//	ns[i] = UpperFirst(word)
-	//}
+	for j := i + 1; j < len(rs); j++ {
+		if !runeIsWord(rs[i]) && runeIsWord(rs[j]) {
+			inWord = false
+		}
+
+		if runeIsLowerChar(rs[j]) && !inWord {
+			buf = append(buf, []byte(string(unicode.ToUpper(rs[j])))...)
+			inWord = true
+		} else {
+			buf = append(buf, []byte(string(rs[j]))...)
+		}
+
+		if runeIsWord(rs[j]) {
+			inWord = true
+		}
+
+		i++
+	}
 
 	return string(buf)
-}
-
-func isWord(c uint8) bool {
-	return isLowerChar(c) || isUpperChar(c)
-}
-
-func isLowerChar(c uint8) bool {
-	return 'a' <= c && c <= 'z'
-}
-
-func isUpperChar(c uint8) bool {
-	return 'A' <= c && c <= 'Z'
 }
 
 // LowerFirst lower first char
@@ -92,10 +76,12 @@ func LowerFirst(s string) string {
 		return s
 	}
 
-	f := s[0]
-	if f >= 'A' && f <= 'Z' {
-		return strings.ToLower(string(f)) + s[1:]
+	rs := []rune(s)
+	f := rs[0]
+	if 'A' <= f && f <= 'Z' {
+		return string(unicode.ToLower(f)) + string(rs[1:])
 	}
+
 	return s
 }
 
@@ -104,11 +90,12 @@ func UpperFirst(s string) string {
 	if len(s) == 0 {
 		return s
 	}
-
-	f := s[0]
-	if f >= 'a' && f <= 'z' {
-		return strings.ToUpper(string(f)) + s[1:]
+	rs := []rune(s)
+	f := rs[0]
+	if 'a' <= f && f <= 'z' {
+		return string(unicode.ToUpper(f)) + string(rs[1:])
 	}
+
 	return s
 }
 
@@ -162,4 +149,16 @@ func CamelCase(s string, sep ...string) string {
 		s = strings.TrimLeft(s, sepChar)
 		return UpperFirst(s)
 	})
+}
+
+func runeIsWord(c rune) bool {
+	return runeIsLowerChar(c) || runeIsUpperChar(c)
+}
+
+func runeIsLowerChar(c rune) bool {
+	return 'a' <= c && c <= 'z'
+}
+
+func runeIsUpperChar(c rune) bool {
+	return 'A' <= c && c <= 'Z'
 }

--- a/strutil/format_test.go
+++ b/strutil/format_test.go
@@ -24,6 +24,8 @@ func TestUpperFirst(t *testing.T) {
 		{"", ""},
 		{"ab", "Ab"},
 		{"Ab", "Ab"},
+		{"中文 support", "中文 support"},
+		{"support 中文", "Support 中文"},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, strutil.UpperFirst(tt.give))
@@ -39,6 +41,8 @@ func TestLowerFirst(t *testing.T) {
 		{"", ""},
 		{"Ab", "ab"},
 		{"ab", "ab"},
+		{"中文 support", "中文 support"},
+		{"Support 中文", "support 中文"},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, strutil.LowerFirst(tt.give))
@@ -60,6 +64,11 @@ func TestUpperWord(t *testing.T) {
 		{"This is a Test.", "This Is A Test."},
 		{"TTtest TThis...good at This", "TTtest TThis...Good At This"},
 		{"test...test...this...is..WOrk", "Test...Test...This...Is..WOrk"},
+		{"试一试中文", "试一试中文"},
+		{"中文也可以upper word", "中文也可以Upper Word"},
+		{"文", "文"},
+		{"wo...shi...中文", "Wo...Shi...中文"},
+		{"...", "..."},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, strutil.UpperWord(tt.give))
@@ -72,6 +81,7 @@ func TestSnakeCase(t *testing.T) {
 		"RangePrice":  "range_price",
 		"rangePrice":  "range_price",
 		"range_price": "range_price",
+		"中文Snake": "中文_snake",
 	}
 
 	for sample, want := range tests {
@@ -88,6 +98,10 @@ func TestCamelCase(t *testing.T) {
 		"rangePrice":   "rangePrice",
 		"range_price":  "rangePrice",
 		"_range_price": "RangePrice",
+		"try中文": "try中文",
+		"_try中文": "Try中文",
+		"中文try": "中文try",
+		"中文_try": "中文Try",
 	}
 
 	for sample, want := range tests {
@@ -96,6 +110,7 @@ func TestCamelCase(t *testing.T) {
 
 	is.Equal("rangePrice", strutil.Camel("range-price", "-"))
 	is.Equal("rangePrice", strutil.CamelCase("range price", " "))
+	is.Equal("中文Try", strutil.CamelCase("中文 try", " "))
 
 	// custom sep char
 	is.Equal("rangePrice", strutil.CamelCase("range+price", "+"))

--- a/strutil/format_test.go
+++ b/strutil/format_test.go
@@ -56,6 +56,10 @@ func TestUpperWord(t *testing.T) {
 		{"Ab", "Ab"},
 		{"hi lo", "Hi Lo"},
 		{"hi lo wr", "Hi Lo Wr"},
+		{"!Test it!", "!Test It!"},
+		{"This is a Test.", "This Is A Test."},
+		{"TTtest TThis...good at This", "TTtest TThis...Good At This"},
+		{"test...test...this...is..WOrk", "Test...Test...This...Is..WOrk"},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, strutil.UpperWord(tt.give))


### PR DESCRIPTION
The `UpperWord()` function is mainly optimized, and make other functions support Chinese characters
`arrutil.Contains()` support array type judge.
Add new function `arrutil.GetRandomOne()` , you can get a random one of items in slice or array form your input.

I wrote the following test code for `UpperWord()`:
```go
func BenchmarkUpperWordNew(b *testing.B) {
    for i := 0; i < b.N; i++ {
        strutil.UpperWord("test test this is WOrk on")
        strutil.UpperWord("test it")
        strutil.UpperWord("Test It")
        strutil.UpperWord("ab")
    }
}

func BenchmarkUpperWordNew(b *testing.B) {
    for i := 0; i < b.N; i++ {
        strutil.UpperWordOld("test test this is WOrk on")
        strutil.UpperWordOld("test it")
        strutil.UpperWordOld("Test It")
        strutil.UpperWordOld("ab")
    }
}
```

I don't know that I tested was correct or wrong, but the results are as follows:
```bash
goos: darwin
goarch: amd64
pkg: github.com/gookit/goutil/strutil
BenchmarkUpperWordNew-16    	 1528623	       774 ns/op
BenchmarkUpperWordOld-16    	 1000000	      1074 ns/op
```

