### PR TITLE
Support time.Duration in mathutil.Int/Uint

### DIFF
--- a/mathutil/convert.go
+++ b/mathutil/convert.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var (
@@ -53,6 +54,8 @@ func ToInt(in interface{}) (iVal int, err error) {
 	case float32:
 		iVal = int(tVal)
 	case float64:
+		iVal = int(tVal)
+	case time.Duration:
 		iVal = int(tVal)
 	case string:
 		iVal, err = strconv.Atoi(strings.TrimSpace(tVal))
@@ -105,6 +108,8 @@ func ToUint(in interface{}) (u64 uint64, err error) {
 	case float32:
 		u64 = uint64(tVal)
 	case float64:
+		u64 = uint64(tVal)
+	case time.Duration:
 		u64 = uint64(tVal)
 	case string:
 		u64, err = strconv.ParseUint(strings.TrimSpace(tVal), 10, 0)
@@ -160,6 +165,8 @@ func ToInt64(in interface{}) (i64 int64, err error) {
 		i64 = int64(tVal)
 	case float64:
 		i64 = int64(tVal)
+	case time.Duration:
+		i64 = int64(tVal)
 	default:
 		err = ErrConvertFail
 	}
@@ -206,6 +213,8 @@ func ToFloat(in interface{}) (f64 float64, err error) {
 		f64 = float64(tVal)
 	case float64:
 		f64 = tVal
+	case time.Duration:
+		f64 = float64(tVal)
 	default:
 		err = ErrConvertFail
 	}

--- a/mathutil/convert_test.go
+++ b/mathutil/convert_test.go
@@ -2,6 +2,7 @@ package mathutil
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -15,6 +16,7 @@ func TestToInt(t *testing.T) {
 		uint(2), uint8(2), uint16(2), uint32(2), uint64(2),
 		float32(2.2), 2.3,
 		"2",
+		time.Duration(2),
 	}
 	errTests := []interface{}{
 		nil,
@@ -81,6 +83,7 @@ func TestToFloat(t *testing.T) {
 		uint(2), uint8(2), uint16(2), uint32(2), uint64(2),
 		float32(2), float64(2),
 		"2",
+		time.Duration(2),
 	}
 	for _, in := range tests {
 		is.Equal(float64(2), MustFloat(in))


### PR DESCRIPTION
[validate](https://github.com/gookit/validate) 并不支持 time.Duration。主要原因是mathuti.Int/Uint 不支持解析 time.Duration。