### PR TITLE
fix map to string panic when map is not nil but map is empty

### DIFF
--- a/maputil/convert.go
+++ b/maputil/convert.go
@@ -42,6 +42,9 @@ func ToString(mp map[string]interface{}) string {
 	if mp == nil {
 		return ""
 	}
+	if len(mp) <= 0 {
+		return "{}"
+	}
 
 	buf := make([]byte, 0, len(mp)*16)
 	buf = append(buf, '{')


### PR DESCRIPTION
修复map在不为nil，但是为空的情况下，buf[:len(buf)-2]会index panic的异常case