### PR TITLE
refactor: replace Readdir(-1) with ioutil.ReadDir

### DIFF
--- a/fsutil/finder/finder.go
+++ b/fsutil/finder/finder.go
@@ -1,6 +1,7 @@
 package finder
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -248,16 +249,12 @@ func (f *FileFinder) findInDir(dirPath string) {
 		return // ignore I/O error
 	}
 
-	// opening
-	d, err := os.Open(dirPath)
+	// sort.Strings(names)
+	// names, _ := d.Readdirnames(-1)
+	stats, err := ioutil.ReadDir(dirPath)
 	if err != nil {
 		return // ignore I/O error
 	}
-
-	// sort.Strings(names)
-	// names, _ := d.Readdirnames(-1)
-	stats, _ := d.Readdir(-1)
-	_ = d.Close() // close dir.
 
 	for _, fi := range stats {
 		baseName := fi.Name()

--- a/fsutil/info.go
+++ b/fsutil/info.go
@@ -1,6 +1,7 @@
 package fsutil
 
 import (
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -86,16 +87,14 @@ func FindInDir(dir string, handleFn HandleFunc, filters ...FilterFunc) (e error)
 		return // ignore I/O error
 	}
 
-	d, err := os.Open(dir)
-	if err != nil {
-		return // ignore I/O error
-	}
-	defer d.Close()
-
 	// names, _ := d.Readdirnames(-1)
 	// sort.Strings(names)
 
-	stats, _ := d.Readdir(-1)
+	stats, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
 	for _, fi := range stats {
 		baseName := fi.Name()
 		filePath := dir + "/" + baseName


### PR DESCRIPTION
We can simplify the following code

```go
dir, err := os.Open(dirname)
if err != nil {
	return err
}
defer dir.Close()

dirs, err := dir.Readdir(-1)
```

with just `ioutil.ReadDir(dirname)`