### PR TITLE
sysutil: non-Linux OS support

### DIFF
--- a/sysutil/clipboard/clipboard.go
+++ b/sysutil/clipboard/clipboard.go
@@ -198,7 +198,7 @@ func (c *Clipboard) ReadTo(w io.Writer) error {
 
 // Available check
 func (c *Clipboard) Available() bool {
-	return c.writeable && c.readable
+	return c.writeable && c.readable && available()
 }
 
 // Writeable check

--- a/sysutil/clipboard/util_darwin.go
+++ b/sysutil/clipboard/util_darwin.go
@@ -11,3 +11,5 @@ func GetWriterBin() string {
 func GetReaderBin() string {
 	return ReaderOnMac
 }
+
+func available() bool { return true }

--- a/sysutil/clipboard/util_unix.go
+++ b/sysutil/clipboard/util_unix.go
@@ -2,6 +2,8 @@
 
 package clipboard
 
+import "os"
+
 // GetWriterBin program name
 func GetWriterBin() string {
 	return WriterOnLin
@@ -10,4 +12,9 @@ func GetWriterBin() string {
 // GetReaderBin program name
 func GetReaderBin() string {
 	return ReaderOnLin
+}
+
+func available() bool {
+	// X clipboard is unavailable when not under X.
+	return os.Getenv("DISPLAY") != ""
 }

--- a/sysutil/clipboard/util_windows.go
+++ b/sysutil/clipboard/util_windows.go
@@ -11,3 +11,5 @@ func GetWriterBin() string {
 func GetReaderBin() string {
 	return ReaderOnWin
 }
+
+func available() bool { return true }

--- a/sysutil/sysutil_unix.go
+++ b/sysutil/sysutil_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows && !darwin
+
 package sysutil
 
 import (


### PR DESCRIPTION
Use the same implementation as for Linux on non-Linux Unix-like
OSes, such as NetBSD and Illumos. IsLinux will return true for these,
but that's probably fine -- close enough :)

For the clipboard package, the tests fail on the console because
xclip and xsel need an X session to run. Add a check for that and
mark the clipboard as unavailable on Unix if DISPLAY is unset.
