### PR TITLE
优化生成随机字符串

### DIFF
--- a/strutil/random.go
+++ b/strutil/random.go
@@ -1,8 +1,10 @@
 package strutil
 
 import (
-	mRand "math/rand"
+	"math"
+	"math/rand"
 	"time"
+	"unsafe"
 
 	"github.com/gookit/goutil/byteutil"
 	"github.com/gookit/goutil/encodes"
@@ -10,8 +12,9 @@ import (
 
 // some consts string chars
 const (
-	Numbers  = "0123456789"
-	HexChars = "0123456789abcdef" // base16
+	MaximumCapacity = 1 << 31
+	Numbers         = "0123456789"
+	HexChars        = "0123456789abcdef" // base16
 
 	AlphaBet  = "abcdefghijklmnopqrstuvwxyz"
 	AlphaBet1 = "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz"
@@ -21,47 +24,84 @@ const (
 	AlphaNum3 = "0123456789AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz"
 )
 
-func newRand() *mRand.Rand {
-	return mRand.New(mRand.NewSource(time.Now().UnixNano()))
+var rn = rand.NewSource(time.Now().UnixNano())
+
+// nearestPowerOfTwo 返回一个大于等于cap的最近的2的整数次幂，参考java8的hashmap的tableSizeFor函数
+// cap 输入参数
+// 返回一个大于等于cap的最近的2的整数次幂
+func nearestPowerOfTwo(cap int) int {
+	n := cap - 1
+	n |= n >> 1
+	n |= n >> 2
+	n |= n >> 4
+	n |= n >> 8
+	n |= n >> 16
+	if n < 0 {
+		return 1
+	} else if n >= MaximumCapacity {
+		return MaximumCapacity
+	}
+	return n + 1
+}
+
+// buildRandomString 生成随机字符串
+// letters 字符串模板
+// length 生成长度
+// 返回一个指定长度的随机字符串
+func buildRandomString(letters string, length int) string {
+	// 仿照strings.Builder
+	// 创建一个长度为 length 的字节切片
+	bytes := make([]byte, length)
+	strLength := len(letters)
+	if strLength <= 0 {
+		return ""
+	} else if strLength == 1 {
+		for i := 0; i < length; i++ {
+			bytes[i] = letters[0]
+		}
+		return *(*string)(unsafe.Pointer(&bytes))
+	}
+	// letters的字符需要使用多少个比特位数才能表示完
+	// letterIdBits := int(math.Ceil(math.Log2(strLength))),下面比上面的代码快
+	letterIdBits := int(math.Log2(float64(nearestPowerOfTwo(strLength))))
+	// 最大的字母id掩码
+	var letterIdMask int64 = 1<<letterIdBits - 1
+	// 可用次数的最大值
+	letterIdMax := 63 / letterIdBits
+	// UnixNano: 1607400451937462000
+	// 循环生成随机字符串
+	for i, cache, remain := length-1, rn.Int63(), letterIdMax; i >= 0; {
+		// 检查随机数生成器是否用尽所有随机数
+		if remain == 0 {
+			cache, remain = rn.Int63(), letterIdMax
+		}
+		// 从可用字符的字符串中随机选择一个字符
+		if idx := int(cache & letterIdMask); idx < len(letters) {
+			bytes[i] = letters[idx]
+			i--
+		}
+		// 右移比特位数，为下次选择字符做准备
+		cache >>= letterIdBits
+		remain--
+	}
+	// 仿照strings.Builder用unsafe包返回一个字符串，避免拷贝
+	// 将字节切片转换为字符串并返回
+	return *(*string)(unsafe.Pointer(&bytes))
 }
 
 // RandomChars generate give length random chars at `a-z`
 func RandomChars(ln int) string {
-	cs := make([]byte, ln)
-	// UnixNano: 1607400451937462000
-	rn := newRand()
-
-	for i := 0; i < ln; i++ {
-		// rand in 0 - 25
-		cs[i] = AlphaBet[rn.Intn(25)]
-	}
-	return string(cs)
+	return buildRandomString(AlphaBet, ln)
 }
 
 // RandomCharsV2 generate give length random chars in `0-9a-z`
 func RandomCharsV2(ln int) string {
-	cs := make([]byte, ln)
-	// UnixNano: 1607400451937462000
-	rn := newRand()
-
-	for i := 0; i < ln; i++ {
-		// rand in 0 - 35
-		cs[i] = AlphaNum[rn.Intn(35)]
-	}
-	return string(cs)
+	return buildRandomString(AlphaNum, ln)
 }
 
 // RandomCharsV3 generate give length random chars in `0-9a-zA-Z`
 func RandomCharsV3(ln int) string {
-	cs := make([]byte, ln)
-	// UnixNano: 1607400451937462000
-	rn := newRand()
-
-	for i := 0; i < ln; i++ {
-		// rand in 0 - 61
-		cs[i] = AlphaNum2[rn.Intn(61)]
-	}
-	return string(cs)
+	return buildRandomString(AlphaNum2, ln)
 }
 
 // RandWithTpl generate random string with give template
@@ -69,16 +109,7 @@ func RandWithTpl(n int, letters string) string {
 	if len(letters) == 0 {
 		letters = AlphaNum2
 	}
-
-	ln := len(letters)
-	cs := make([]byte, n)
-	rn := newRand()
-
-	for i := 0; i < n; i++ {
-		// rand in 0 - ln
-		cs[i] = letters[rn.Intn(ln)]
-	}
-	return byteutil.String(cs)
+	return buildRandomString(letters, n)
 }
 
 // RandomString generate.


### PR DESCRIPTION
# 优化随机字符串生成

## 背景

原来的随机字符串生成代码在Windows环境下就存在BUG，可参考[Function RandomChars has bug · Issue #121 · gookit/goutil (github.com)](https://github.com/gookit/goutil/issues/121)

在Windows本地测试发现如果使用for循环重复生成随机字符串存在相同的情况,代码如下：

```go
func main() {
	for i := 0; i < 10; i++ {
		println(strutil.RandomCharsV3(10))
	}
}
```

输出打印如下：

```bash
GOROOT=C:\Users\zhb15\sdk\go1.21.3 #gosetup
GOPATH=D:\Go\WorkSpace #gosetup
C:\Users\zhb15\sdk\go1.21.3\bin\go.exe build -o C:\Users\zhb15\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___go_build_mytest_com_zhb_utils.exe mytest/com/zhb/utils #gosetup
C:\Users\zhb15\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___go_build_mytest_com_zhb_utils.exe
p35cdB4ntT
p35cdB4ntT
p35cdB4ntT
p35cdB4ntT
p35cdB4ntT
p35cdB4ntT
p35cdB4ntT
qgHpMOu2R6
qgHpMOu2R6
qgHpMOu2R6

进程 已完成，退出代码为 0
```

正好最近看到一篇关于随机字符串生成的文章，原文链接：[Golang生成随机字符串的八种方式与性能测试-云社区-华为云 (huaweicloud.com)](https://bbs.huaweicloud.com/blogs/419489?utm_source=juejin&utm_medium=bbs-ex&utm_campaign=other&utm_content=content#H21)，[How to generate a random string of a fixed length in Go? - Stack Overflow](https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go)

所以打算根据文章中提到的方法优化`strutil`的随机字符串生成方法

## 实现

新增的方法有2个`nearestPowerOfTwo`和`buildRandomString`，`nearestPowerOfTwo`方法是求大于等于字符模板的最近的2的整数次幂，这个方法参考java8的hashmap的tableSizeFor函数，可参考文章：[HashMap部分源码简析 | 柳门竹巷 (zhbblog.top)](https://www.zhbblog.top/2021/08/16/HashMap部分源码简析/#tableSizeFor)

```java
/**
 * Returns a power of two size for the given target capacity.
 */
//返回大于输入参数且最近的2的整数次幂的数。比如10，则返回16
static final int tableSizeFor(int cap) {
    int n = cap - 1;
    n |= n >>> 1;
    n |= n >>> 2;
    n |= n >>> 4;
    n |= n >>> 8;
    n |= n >>> 16;
    return (n < 0) ? 1 : (n >= MAXIMUM_CAPACITY) ? MAXIMUM_CAPACITY : n + 1;
}
```

`buildRandomString`主要用于根据输入的字符串模板，生成指定长度的随机字符串，具体原理请参考上诉链接

## 结果

### 测试结果

现在在Windows本地测试结果如下,代码：

```go
func main() {
	for i := 0; i < 10; i++ {
		println(testUtil.RandomCharsV3(10))
	}
}
```

输出打印如下：

```bash
GOROOT=C:\Users\zhb15\sdk\go1.21.3 #gosetup
GOPATH=D:\Go\WorkSpace #gosetup
C:\Users\zhb15\sdk\go1.21.3\bin\go.exe build -o C:\Users\zhb15\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___go_build_mytest_com_zhb_utils.exe mytest/com/zhb/utils #gosetup
C:\Users\zhb15\AppData\Local\JetBrains\GoLand2023.3\tmp\GoLand\___go_build_mytest_com_zhb_utils.exe
e4dKh62ENr
cZfsXSTxhB
n8lGE8rE7f
ftiDJX8NHU
viz89Ur6Bb
j469ymTSQr
fyfcHHeHvq
wDoZelPwlL
BzRHQSgPIN
LzybA6Jz1e

进程 已完成，退出代码为 0
```

### nearestPowerOfTwo方法

返回大于输入参数且最近的2的整数次幂的数方法测试如下，代码：

```go
func BenchmarkApproach1(b *testing.B) {
    for i := 0; i < b.N; i++ {
       _ = int(math.Log2(float64(nearestPowerOfTwo(b.N))))
    }
}

func BenchmarkApproach2(b *testing.B) {
    for i := 0; i < b.N; i++ {
       _ = math.Ceil(math.Log2(float64(b.N)))
    }
}
```

输入打印如下：

```bash
$ go test -benchmem -bench .
goos: windows
goarch: amd64
pkg: mytest/com/zhb/utils
cpu: 12th Gen Intel(R) Core(TM) i5-12600KF
BenchmarkApproach1-16           277866668                4.158 ns/op           0 B/op          0 allocs/op
BenchmarkApproach2-16           151868052                7.809 ns/op           0 B/op          0 allocs/op
PASS
ok      mytest/com/zhb/utils    4.316s
```

### 优化前后性能对比

优化前后性能对比，代码如下：

```go
func BenchmarkApproach3(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = testUtil.RandomChars(1 << 10)
	}
}

func BenchmarkApproach4(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = strutil.RandomChars(1 << 10)
	}
}

func BenchmarkApproach5(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = testUtil.RandomCharsV2(1 << 10)
	}
}

func BenchmarkApproach6(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = strutil.RandomCharsV2(1 << 10)
	}
}

func BenchmarkApproach7(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = testUtil.RandomCharsV3(1 << 10)
	}
}

func BenchmarkApproach8(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = strutil.RandomCharsV3(1 << 10)
	}
}
```

输出打印如下：

```bash
$ go test -benchmem -bench .
goos: windows
goarch: amd64
pkg: mytest/com/zhb/utils
cpu: 12th Gen Intel(R) Core(TM) i5-12600KF
BenchmarkApproach3-16             288414              3954 ns/op            1024 B/op          1 allocs/op
BenchmarkApproach4-16             108159             11052 ns/op            7472 B/op          4 allocs/op
BenchmarkApproach5-16             136956              8588 ns/op            1024 B/op          1 allocs/op
BenchmarkApproach6-16             107840             11156 ns/op            7472 B/op          4 allocs/op
BenchmarkApproach7-16             749732              1783 ns/op            1024 B/op          1 allocs/op
BenchmarkApproach8-16             107077             11216 ns/op            7472 B/op          4 allocs/op
PASS
ok      mytest/com/zhb/utils    8.544s
```

### 优化前后准确性对比

优化前后准确性对比，代码如下：

```go
func TestApproach1(t *testing.T) {
	println("Approach1-testUtil")
	for i := 0; i < 10; i++ {
		println(testUtil.RandomChars(32))
	}
	println("Approach1-strUtil")
	for i := 0; i < 10; i++ {
		println(strutil.RandomChars(32))
	}
}

func TestApproach2(t *testing.T) {
	println("Approach2-testUtil")
	for i := 0; i < 10; i++ {
		println(testUtil.RandomCharsV2(32))
	}
	println("Approach2-strUtil")
	for i := 0; i < 10; i++ {
		println(strutil.RandomCharsV2(32))
	}
}

func TestApproach3(t *testing.T) {
	println("Approach3-testUtil")
	for i := 0; i < 10; i++ {
		println(testUtil.RandomCharsV3(32))
	}
	println("Approach3-strUtil")
	for i := 0; i < 10; i++ {
		println(strutil.RandomCharsV3(32))
	}
}
```

输出打印如下：

```bash
$ go test -benchmem -bench .
Approach1-testUtil
qfradxxxugivfeqdndkmwablgblbpmrq
iawlwilkjsyfbfyibiesrgcvxcktihqx
uvlimlwfvheezhoajjmugufdnijfonrw
heotinzkjwydwefjxxjrlbwajstherqo
klzwlmbmoqnhesinxduvnwarcdztwfzo
qtxknpgwkaecthmkcgpylqkqhblnwghv
qrmkukeiigoogfnuglhnelhoodctnnor
ozwjggaoccrujwsydzurhppvutcotaok
ezymohbmmkgfioujstqddlumydtoktji
ucsisvhejomsefnkmmfjwwidyxmifycm
Approach1-strUtil
nwjhtxwrojjrpumddjfmkuxxksxpturm
nwjhtxwrojjrpumddjfmkuxxksxpturm
nwjhtxwrojjrpumddjfmkuxxksxpturm
cxtldieyfuevrlqbrhomdsyahfdfbhml
cxtldieyfuevrlqbrhomdsyahfdfbhml
cxtldieyfuevrlqbrhomdsyahfdfbhml
cxtldieyfuevrlqbrhomdsyahfdfbhml
cxtldieyfuevrlqbrhomdsyahfdfbhml
cxtldieyfuevrlqbrhomdsyahfdfbhml
cxtldieyfuevrlqbrhomdsyahfdfbhml
Approach2-testUtil
fut0tk6qyg6zas3w428bg9xo79a8apek
2xd7779ws7dn3kto63vfycwiva9kwhf2
c5oi8awgiuyza7cba8s4sjw0qmygciu9
8w9d2ng9gndb6o99ymbcfcakjehtauxk
c0zsh48oirvzvq8u0q6z5sxonmw4w89y
4so6b8fqlyhhiulqz4czfckn9mv5foxf
qzigv9vbk1byyew2k22n9on7qg0xtr7g
8bsnlqcy12qk6m2ls83xf6ro6x2m1tz1
9ielerjzg75ugjhq10lr0u8rwer6hwpf
3zcl0w0q0c10vqyicef2mpsx2dgwfvy3
Approach2-strUtil
yhjgeb38po4d5k1511bl6x5osxtx0vnj
yhjgeb38po4d5k1511bl6x5osxtx0vnj
4vlcpg5j75j0qrc2haocto40tfs30nah
4vlcpg5j75j0qrc2haocto40tfs30nah
4vlcpg5j75j0qrc2haocto40tfs30nah
4vlcpg5j75j0qrc2haocto40tfs30nah
4vlcpg5j75j0qrc2haocto40tfs30nah
4vlcpg5j75j0qrc2haocto40tfs30nah
4vlcpg5j75j0qrc2haocto40tfs30nah
4vlcpg5j75j0qrc2haocto40tfs30nah
Approach3-testUtil
gPcjM6IBQ9CsrMqcHNGlSGHJS9sG7jgG
8ZqiXVkryXPmxq0lIXw03gyKMVxz1u89
gk2qzEN1GNQ57vkBOy6jWQs3VhlhHCBQ
ZtpmUIfuhmNE6X9jrmZumFpvEl8hAmzh
oA5trh14GyS59O0spbdVrqFSKdaGmcg7
UhqZTGllUjA28AVpUmiajH61y0aNNmpT
rDwSgIQPJauBzzLO2Ka9el5MgoP4nNso
CEoqbiQfT8M1pEIB9QTYzR5r0LCpQCtn
2fNUKyRiq7Zl3f3bfIw16EKiyHSZDG3J
SpM0gUnE31p01r6Ixth8HXFyZnkLQneB
Approach3-strUtil
taNxbaWkYLwfFF50ko3mLtll1BX1gW2K
taNxbaWkYLwfFF50ko3mLtll1BX1gW2K
By4WjX8QiNPz10b38DIHcFn0KJQJsMrB
By4WjX8QiNPz10b38DIHcFn0KJQJsMrB
By4WjX8QiNPz10b38DIHcFn0KJQJsMrB
By4WjX8QiNPz10b38DIHcFn0KJQJsMrB
By4WjX8QiNPz10b38DIHcFn0KJQJsMrB
By4WjX8QiNPz10b38DIHcFn0KJQJsMrB
By4WjX8QiNPz10b38DIHcFn0KJQJsMrB
By4WjX8QiNPz10b38DIHcFn0KJQJsMrB
PASS
ok      mytest/com/zhb/utils    0.044s
```

优化后实际效果仍有待完整测试
