### PR TITLE
fix: correct typos in comments

### DIFF
--- a/arrutil/strings.go
+++ b/arrutil/strings.go
@@ -77,7 +77,7 @@ func StringsRemove(ss []string, s string) []string {
 	})
 }
 
-// StringsFilter given strings, default will filter emtpy string.
+// StringsFilter given strings, default will filter empty string.
 //
 // Usage:
 //

--- a/dump/dumper.go
+++ b/dump/dumper.go
@@ -293,7 +293,7 @@ func (d *Dumper) printRValue(t reflect.Type, v reflect.Value) {
 			break // don't print v again
 		}
 
-		// up: special handel time.Time struct
+		// up: special handle time.Time struct
 		if t == timeType {
 			d.printf("time.Time(%s),\n", d.ColorTheme.string(d.fmtTimeValue(v)))
 			break

--- a/internal/gendoc/main.go
+++ b/internal/gendoc/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	// hidden pacakges.
+	// hidden packages.
 	hidden = []string{
 		"basefn",
 		"netutil",

--- a/strutil/textscan/scanner.go
+++ b/strutil/textscan/scanner.go
@@ -150,7 +150,7 @@ func (s *TextScanner) matchToken(text string) (ok bool) {
 		}
 	}
 
-	// emtpy line, match next valid token
+	// empty line, match next valid token
 	if strings.TrimSpace(text) == "" {
 		ok, text := s.ScanNext()
 		if ok {


### PR DESCRIPTION
Fix four typos found in code comments across the codebase:

- `emtpy` -> `empty` in `arrutil/strings.go` and `strutil/textscan/scanner.go`
- `handel` -> `handle` in `dump/dumper.go`
- `pacakges` -> `packages` in `internal/gendoc/main.go`

Found with [codespell](https://github.com/codespell-project/codespell).